### PR TITLE
Added notify option that gets passed to browserSync.

### DIFF
--- a/lib/lite-server.js
+++ b/lib/lite-server.js
@@ -9,6 +9,8 @@ yargs.option('files', {
   type: 'array'
 });
 
+yargs.boolean('notify').default('notify', true);
+
 var argv = yargs.argv;
 var openPath = getOpenPath();
 var options =
@@ -46,4 +48,5 @@ sync.init({
     ]
   },
   files: options.files,
+  notify: argv.notify
 });


### PR DESCRIPTION
Sometimes it's annoying that browserSync overlays a change notification in the browser for every change.
This can be supressed by setting the BrowserSync option 'notify' to false.

This change adds a 'notify' boolean command-line option that has a default of true. This option gets passed
to browserSync and it means that notification can be turned off by passing --no-notify on the command-line
to lite-server