### PR TITLE
change port declaration

### DIFF
--- a/lib/lite-server.js
+++ b/lib/lite-server.js
@@ -13,7 +13,6 @@ var argv = yargs.argv;
 var openPath = getOpenPath();
 var options =
   {
-    port: argv.port || 3000,
     openPath: openPath,
     files: argv.files ? argv.files : [
       openPath + '/**/*.html',
@@ -37,8 +36,8 @@ function getOpenPath() {
 }
 
 sync.init({
+  port: argv.port || 3000,
   server: {
-    port: options.port,
     baseDir: options.baseDir,
     middleware: [
       log(),


### PR DESCRIPTION
* Currently passing in the port number in the arguments object does not change the port number
* This fix declares the port number in the port options in init, as per the browsersync options