### PR TITLE
Added an option for different index file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Sets the port to serve. Defaults to 3000.
 `lite-server --port 3000`
 
 ### open
-Which folder to holds the `index.html`. Defaults to `./`
+Which folder to holds the index file (`index.html` by default). Defaults to `./`
 
 `lite-server --open src`
 
@@ -46,4 +46,7 @@ or to serve from multiple folders
 
 `lite-server --baseDir ./src --baseDir ./`
 
+### indexFile
+Which file will be opened after the server starts. Defaults to `index.html`
 
+`lite-server --indexFile main.html`

--- a/lib/lite-server.js
+++ b/lib/lite-server.js
@@ -11,7 +11,7 @@ yargs.option('files', {
 
 var argv = yargs.argv;
 var openPath = getOpenPath();
-var file = argv.file || 'index.html'
+var indexFile = argv.indexFile || 'index.html'
 var options =
   {
     openPath: openPath,
@@ -21,7 +21,7 @@ var options =
       openPath + '/**/*.js'
     ],
     baseDir: argv.baseDir || './',
-    fallback: '/' + openPath + '/' + file
+    fallback: '/' + openPath + '/' + indexFile
   };
 
 if (argv.verbose) {

--- a/lib/lite-server.js
+++ b/lib/lite-server.js
@@ -11,6 +11,7 @@ yargs.option('files', {
 
 var argv = yargs.argv;
 var openPath = getOpenPath();
+var file = argv.file || 'index.html'
 var options =
   {
     openPath: openPath,
@@ -20,7 +21,7 @@ var options =
       openPath + '/**/*.js'
     ],
     baseDir: argv.baseDir || './',
-    fallback: '/' + openPath + '/index.html'
+    fallback: '/' + openPath + '/' + file
   };
 
 if (argv.verbose) {


### PR DESCRIPTION
In some cases, you may need to use file with another name as an index file. For example, I am using it to serve electronjs frontend for simple UI debugging and the index file is called 'main.html'. This way, you don't need to navigate every time. Simple option defaulting to usual 'index.html'