### PR TITLE
Add support for browsersync configuration in external rc file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-2016 John Papa
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,51 +2,41 @@
 
 Lightweight *development only* node server that serves a web app, opens it in the browser, refreshes when html or javascript change, injects CSS changes using sockets, and has a fallback page when a route is not found.
 
-## Get Started
+## Usage
 
-### Serve the current folder and `./index.html`
-Serve from the current folder and open (browse to) the default file (usually index.html) in that folder.
+The default behavior serves from the current folder, opens a browser, and applies a HTML5 route fallback to `./index.html`.
 
-`lite-server`
+```
+$ lite-server
+```
 
-### Serve the current folder and `./src/index.html`
-Serve from the current folder and open (browse to) the default file (usually index.html) in the `src` folder.
+## Custom configuration
+lite-server utilizes [Browsersync](https://www.browsersync.io/), and allows for configuration overrides via a local `bs-config.json` or `bs-config.js` file in your project.
 
-`lite-server --open src`
+For example, to change the server port, watched file paths, and base directory for your project (`bs-config.json`):
+```
+{
+  "port": 8000,
+  "files": ["./src/**/*.html", "./src/**/*.css", "./src/**/*.js"],
+  "server": { "baseDir": "./src" }
+}
+```
 
-### Serve and log all options
+A more complicated example with modifications to the server middleware ('bs-config.js'):
+```
+// Requires running `npm i connect-history-api-fallback --save-dev` in local project
+module.exports = {
+  server: {
+    middleware: {
+       0: null,  // removes logger middleware
+       1: require('connect-history-api-fallback')({index: '/index.html', verbose: true})
+    }
+  }
+};
+```
 
-`lite-server --verbose`
+A list of the entire set of Browsersync options can be found in its docs: <http://www.browsersync.io/docs/options/>
 
-## Options
+## License
 
-### port
-Sets the port to serve. Defaults to 3000.
-
-`lite-server --port 3000`
-
-### open
-Which folder to holds the index file (`index.html` by default). Defaults to `./`
-
-`lite-server --open src`
-
-### files
-
-Array of file patterns to watch. Defaults to all html, css and js.
-
-`lite-server --files '/**/*.html' '/**/*.css' '/**/*.js'`
-
-### baseDir
-
-Folder (or collection of folders) to serve. Defaults to `./`. Use this when you want to specify which folders you want to serve assets from.
-
-`lite-server --baseDir './'`
-
-or to serve from multiple folders
-
-`lite-server --baseDir ./src --baseDir ./`
-
-### indexFile
-Which file will be opened after the server starts. Defaults to `index.html`
-
-`lite-server --indexFile main.html`
+Code released under the [MIT license](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For example, to change the server port, watched file paths, and base directory f
 }
 ```
 
-A more complicated example with modifications to the server middleware ('bs-config.js'):
+A more complicated example with modifications to the server middleware (`bs-config.js`):
 ```js
 // Requires running `npm i connect-history-api-fallback --save-dev` in local project
 module.exports = {

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ $ lite-server
 lite-server utilizes [Browsersync](https://www.browsersync.io/), and allows for configuration overrides via a local `bs-config.json` or `bs-config.js` file in your project.
 
 For example, to change the server port, watched file paths, and base directory for your project (`bs-config.json`):
-```
+```json
 {
   "port": 8000,
   "files": ["./src/**/*.html", "./src/**/*.css", "./src/**/*.js"],
@@ -23,7 +23,7 @@ For example, to change the server port, watched file paths, and base directory f
 ```
 
 A more complicated example with modifications to the server middleware ('bs-config.js'):
-```
+```js
 // Requires running `npm i connect-history-api-fallback --save-dev` in local project
 module.exports = {
   server: {

--- a/lib/config-defaults.js
+++ b/lib/config-defaults.js
@@ -10,9 +10,9 @@ module.exports = {
     ],
     "server": {
       "baseDir": './',
-      "middleware": {
-        0: log({format: '%date %status %method %url'}),
-        1: historyFallback({"index": '/index.html'})
-      }
+      "middleware": [
+        log({format: '%date %status %method %url'}),
+        historyFallback({"index": '/index.html'})
+      ]
     }
 };

--- a/lib/config-defaults.js
+++ b/lib/config-defaults.js
@@ -1,0 +1,18 @@
+var historyFallback = require('connect-history-api-fallback');
+var log = require('connect-logger');
+/*
+ | For up-to-date information about the options:
+ |   http://www.browsersync.io/docs/options/
+ */
+module.exports = {
+    "files": [
+      './**/*.html', './**/*.css', './**/*.js'
+    ],
+    "server": {
+      "baseDir": './',
+      "middleware": {
+        0: log({format: '%date %status %method %url'}),
+        1: historyFallback({"index": '/index.html'})
+      }
+    }
+};

--- a/lib/lite-server.js
+++ b/lib/lite-server.js
@@ -21,5 +21,10 @@ try {
 } catch (err) { } // silent: optional load
 _.merge(options, overrides);
 
+// Fixes browsersync error when overriding middleware array
+if (options.server.middleware) {
+  options.server.middleware = _.compact(options.server.middleware);
+}
+
 // Run browser-sync
 browserSync.init(options);

--- a/lib/lite-server.js
+++ b/lib/lite-server.js
@@ -1,45 +1,25 @@
 'use strict';
-
-var historyFallback = require('connect-history-api-fallback');
-var log = require('connect-logger');
-var yargs = require('yargs');
-var sync = require('browser-sync').create();
+/**
+ * lite-server : Simple server for angular/SPA projects
+ *
+ * Simply loads some default browser-sync options that apply to NG/SPA sites,
+ * applies custom config overrides from user's own local `bs-config.{js|json}` file,
+ * and launches browser-sync.
+ */
+var browserSync = require('browser-sync').create();
 var path = require('path');
+var _ = require('lodash');
 
-// Load optional browser-sync config file
+// Load defaults
+var options = require('./config-defaults');
+
+// Load optional browser-sync config file from user's project dir
 var bsConfigPath = path.resolve('bs-config');
-var options = {};
+var overrides = {};
 try {
-  options = require(bsConfigPath);
-} catch (err) { } // silent error
-
-// Process CLI arguments
-yargs.option('files', {
-  describe: 'array of file paths to watch',
-  type: 'array'
-});
-var argv = yargs.argv;
-setArgOverrides(options, argv);
-
-function setArgOverrides(o, argv) {
-  o.port = argv.port || o.port || 3000;
-  o.openPath = argv.open || o.openPath || '.';
-  o.files = argv.files || o.files || [
-    o.openPath + '/**/*.html',
-    o.openPath + '/**/*.css',
-    o.openPath + '/**/*.js'
-  ];
-  o.server = o.server || {};
-  o.server.baseDir = argv.baseDir || o.server.baseDir || './';
-  o.server.middleware = o.server.middleware || [
-    log(),
-    historyFallback({ index: '/' + o.openPath + '/' + (argv.indexFile || 'index.html') })
-  ]
-}
-
-if (argv.verbose) {
-  console.log('options', options);
-}
+  overrides = require(bsConfigPath);
+} catch (err) { } // silent: optional load
+_.merge(options, overrides);
 
 // Run browser-sync
-sync.init(options);
+browserSync.init(options);

--- a/lib/lite-server.js
+++ b/lib/lite-server.js
@@ -1,49 +1,45 @@
+'use strict';
+
 var historyFallback = require('connect-history-api-fallback');
 var log = require('connect-logger');
 var yargs = require('yargs');
 var sync = require('browser-sync').create();
-var defaultOpenPath = '';
+var path = require('path');
 
+// Load optional browser-sync config file
+var bsConfigPath = path.resolve('bs-config');
+var options = {};
+try {
+  options = require(bsConfigPath);
+} catch (err) { } // silent error
+
+// Process CLI arguments
 yargs.option('files', {
   describe: 'array of file paths to watch',
   type: 'array'
 });
-
 var argv = yargs.argv;
-var openPath = getOpenPath();
-var indexFile = argv.indexFile || 'index.html'
-var options =
-  {
-    openPath: openPath,
-    files: argv.files ? argv.files : [
-      openPath + '/**/*.html',
-      openPath + '/**/*.css',
-      openPath + '/**/*.js'
-    ],
-    baseDir: argv.baseDir || './',
-    fallback: '/' + openPath + '/' + indexFile
-  };
+setArgOverrides(options, argv);
+
+function setArgOverrides(o, argv) {
+  o.port = argv.port || o.port || 3000;
+  o.openPath = argv.open || o.openPath || '.';
+  o.files = argv.files || o.files || [
+    o.openPath + '/**/*.html',
+    o.openPath + '/**/*.css',
+    o.openPath + '/**/*.js'
+  ];
+  o.server = o.server || {};
+  o.server.baseDir = argv.baseDir || o.server.baseDir || './';
+  o.server.middleware = o.server.middleware || [
+    log(),
+    historyFallback({ index: '/' + o.openPath + '/' + (argv.indexFile || 'index.html') })
+  ]
+}
 
 if (argv.verbose) {
   console.log('options', options);
 }
 
-function getOpenPath() {
-  var src = argv.open || defaultOpenPath;
-  if (!src) {
-    return '.'
-  }
-  return src;
-}
-
-sync.init({
-  port: argv.port || 3000,
-  server: {
-    baseDir: options.baseDir,
-    middleware: [
-      log(),
-      historyFallback({ index: options.fallback })
-    ]
-  },
-  files: options.files,
-});
+// Run browser-sync
+sync.init(options);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lite-server",
-  "version": "1.3.4",
+  "version": "2.0.0",
   "description": "Lightweight development node server for serving a web app, providing a fallback for browser history API, loading in the browser, and injecting scripts on the fly.",
   "main": "./lib/lite-server",
   "scripts": {},
@@ -19,7 +19,7 @@
     "browser-sync": "^2.11.1",
     "connect-history-api-fallback": "^1.1.0",
     "connect-logger": "0.0.1",
-    "yargs": "^3.32.0"
+    "lodash": "^4.1.0"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Addresses #1 

This PR adds support for an external configuration file `bs-config.js` (or `bs-config.json`) that matches [Browser Sync's config format](https://www.browsersync.io/docs/options/). 

You can run `browser-sync init` in the angular2-tour-of-heroes repo to generate a sample config file (must `npm i -g browser-sync` beforehand).

*Most* `lite-server` command-line arguments will override any configuration file settings. All except for the `--indexFile` argument, which will not be applied if the configuration file has explicit middleware defined. We can fix this if it is a problem.

The README still needs to be updated, if this change is agreed upon.