### PR TITLE
Add path as proxy functionality, mainly for APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,22 @@ or to serve from multiple folders
 Which file will be opened after the server starts. Defaults to `index.html`
 
 `lite-server --indexFile main.html`
+
+### api
+Redirect calls to `/api/something` to `http://localhost:3002/api/something`.
+
+`lite-server --api`
+
+or redirect to `http://localhost:4000/somewhat/api/something`
+
+`lite-server --api http://localhost:4000/somewhat`
+
+
+### api-context
+Redirect calls to `/something` to `http://localhost:3002/something`.
+
+`lite-server --api-context '/something'`
+
+or redirect to `http://localhost:4000/somewhat/something`
+
+`lite-server --api http://localhost:4000/somewhat --api-context '/something'`

--- a/lib/lite-server.js
+++ b/lib/lite-server.js
@@ -1,12 +1,27 @@
 var historyFallback = require('connect-history-api-fallback');
 var log = require('connect-logger');
+var proxyMiddleware = require('http-proxy-middleware');
 var yargs = require('yargs');
 var sync = require('browser-sync').create();
 var defaultOpenPath = '';
+var defaultApiContext = '/api'
+var defaultApiTarget = 'http://localhost:3002/'
 
 yargs.option('files', {
   describe: 'array of file paths to watch',
   type: 'array'
+});
+
+yargs.option('api', {
+  describe: 'enable api proxy',
+  type: 'string',
+  default: false
+});
+
+yargs.option('api-context', {
+  describe: 'api context matcher',
+  type: 'string',
+  default: false
 });
 
 var argv = yargs.argv;
@@ -21,8 +36,16 @@ var options =
       openPath + '/**/*.js'
     ],
     baseDir: argv.baseDir || './',
-    fallback: '/' + openPath + '/' + indexFile
+    fallback: '/' + openPath + '/' + indexFile,
+    api: {
+      enabled: argv.api !== false || argv['api-context'] !== false
+    }
   };
+
+if (options.api.enabled) {
+  options.api.context = argv['api-context'] ? argv['api-context'] : defaultApiContext;
+  options.api.target = argv.api ? argv.api : defaultApiTarget;
+}
 
 if (argv.verbose) {
   console.log('options', options);
@@ -36,14 +59,24 @@ function getOpenPath() {
   return src;
 }
 
+var middleware = [
+  log(),
+  historyFallback({ index: options.fallback })
+];
+
+if (options.api.enabled) {
+  var proxy = proxyMiddleware(options.api.context, { target: options.api.target });
+  middleware.push(function(req, res, next) {
+    req.url = req.originalUrl;
+    proxy(req, res, next);
+  });
+}
+
 sync.init({
   port: argv.port || 3000,
   server: {
     baseDir: options.baseDir,
-    middleware: [
-      log(),
-      historyFallback({ index: options.fallback })
-    ]
+    middleware: middleware
   },
   files: options.files,
 });

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "browser-sync": "^2.11.1",
     "connect-history-api-fallback": "^1.1.0",
     "connect-logger": "0.0.1",
+    "http-proxy-middleware": "^0.9.1",
     "yargs": "^3.32.0"
   },
   "devDependencies": {}


### PR DESCRIPTION
I'm not entirely sure, if this is wanted, because it's called '**lite**-server', but I need this functionally and I didn't want to keep it to myself.

Note, that I had to force `req.url` in [lib/lite-server.js#L70](https://github.com/michel-zimmer/lite-server/blob/dd41dcbd8eabc1fb1e7e6fd7e47f54263e5f8bda/lib/lite-server.js#L70) to make it work. I'm not sure if that's the desired behavior / usage, but I wasn't able to get it to work without this workaround.