### PR TITLE
Add support for reloadDelay and reloadDebounce

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ Array of file patterns to watch. Defaults to all html, css and js.
 
 `lite-server --files '/**/*.html' '/**/*.css' '/**/*.js'`
 
+### debounce
+
+Restrict the frequency in which browser reload events are emitted in milliseconds. Defaults to 0.
+
+`lite-server --debounce 250`
+
+### delay
+
+Time in milliseconds to wait before instructing the browser to reload/inject following a file change event. Defaults to 0.
+
+`lite-server --delay 250`
+
 ### baseDir
 
 Folder (or collection of folders) to serve. Defaults to `./`. Use this when you want to specify which folders you want to serve assets from.

--- a/lib/lite-server.js
+++ b/lib/lite-server.js
@@ -11,7 +11,7 @@ yargs.option('files', {
 
 var argv = yargs.argv;
 var openPath = getOpenPath();
-var indexFile = argv.indexFile || 'index.html'
+var indexFile = argv.indexFile || 'index.html';
 var options =
   {
     openPath: openPath,
@@ -21,7 +21,9 @@ var options =
       openPath + '/**/*.js'
     ],
     baseDir: argv.baseDir || './',
-    fallback: '/' + openPath + '/' + indexFile
+    fallback: '/' + openPath + '/' + indexFile,
+    reloadDelay: argv.delay || 0,
+    reloadDebounce: argv.debounce || 0
   };
 
 if (argv.verbose) {
@@ -31,7 +33,7 @@ if (argv.verbose) {
 function getOpenPath() {
   var src = argv.open || defaultOpenPath;
   if (!src) {
-    return '.'
+    return '.';
   }
   return src;
 }
@@ -46,4 +48,6 @@ sync.init({
     ]
   },
   files: options.files,
+  reloadDelay: options.reloadDelay,
+  reloadDebounce: options.reloadDebounce
 });


### PR DESCRIPTION
This PR exposes the `reloadDelay` and `reloadDebounce` settings of BrowserSync to the user via CLI args.