### PR TITLE
Enable verbosity for 

### DIFF
--- a/lib/lite-server.js
+++ b/lib/lite-server.js
@@ -42,7 +42,10 @@ sync.init({
     baseDir: options.baseDir,
     middleware: [
       log(),
-      historyFallback({ index: options.fallback })
+      historyFallback({ 
+        index: options.fallback,
+        verbose: argv.verbose 
+      })
     ]
   },
   files: options.files,


### PR DESCRIPTION
Sometimes it can be helpful to see which concret request causes a fallback. Hence, ```connect-history-api-fallback``` provides the [verbose](https://github.com/bripkens/connect-history-api-fallback#verbose) option for such cases.

This PR supports this by passing through the already existing ```verbose``` argument use case.