### PR TITLE
Fix files overriding and css inject issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For example, to change the server port, watched file paths, and base directory f
 ```json
 {
   "port": 8000,
-  "files": ["./src/**/*.html", "./src/**/*.css", "./src/**/*.js"],
+  "files": ["./src/**/*.{html,htm,css,js}"],
   "server": { "baseDir": "./src" }
 }
 ```

--- a/lib/config-defaults.js
+++ b/lib/config-defaults.js
@@ -5,14 +5,13 @@ var log = require('connect-logger');
  |   http://www.browsersync.io/docs/options/
  */
 module.exports = {
-    "files": [
-      './**/*.html', './**/*.css', './**/*.js'
-    ],
-    "server": {
-      "baseDir": './',
-      "middleware": [
-        log({format: '%date %status %method %url'}),
-        historyFallback({"index": '/index.html'})
-      ]
-    }
+  injectChanges: false, // workaround for NG2 styleUrl loading
+  files: ['./**/*.{html,htm,css,js}'],
+  server: {
+    baseDir: './',
+    middleware: [
+      log({format: '%date %status %method %url'}),
+      historyFallback({"index": '/index.html'})
+    ]
+  }
 };


### PR DESCRIPTION
Contains fixes for two issues:

1. The `files:` option had an array of 3 paths, which can be problematic for users that want to override the option. Due to the deep merge behavior of lodash, default array items will get overwritten by the overriding items. If the overriding array does not contain the same number of items as the original array there can be an unexpected/unintuitive difference of array items in the set. By changing the default `files:` option to only 1 array item, it solves possible confusion from users who need to override the option.
2. The Angular2 CSS files in [angular2-tour-of-heroes](https://github.com/johnpapa/angular2-tour-of-heroes) were not being automatically injected with Browsersync. The behavior of the Browsersync client is not currently compatible with the way NG2 loads CSS files through the `styleUrls` Component feature. I've added the `injectChanges: false` to always force a reload for CSS changes to work around this issue.