### PR TITLE
feat(bin): added run time option to config file path and name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ The default behavior serves from the current folder, opens a browser, and applie
 
 lite-server uses [BrowserSync](https://www.browsersync.io/), and allows for configuration overrides via a local `bs-config.json` or `bs-config.js` file in your project.
 
+You can provide custom path to your config file via `-c` or `--config=` run time options:
+```bash
+lite server -c configs/my-bs-config.js
+```
+
 For example, to change the server port, watched file paths, and base directory for your project, create a `bs-config.json` in your project's folder:
 ```json
 {

--- a/lib/lite-server.js
+++ b/lib/lite-server.js
@@ -9,12 +9,13 @@
 var browserSync = require('browser-sync').create();
 var path = require('path');
 var _ = require('lodash');
+var argv = require('minimist')(process.argv.slice(2));
 
 // Load defaults
 var options = require('./config-defaults');
-
+var bsConfigName = argv.c || argv.config || 'bs-config';
 // Load optional browser-sync config file from user's project dir
-var bsConfigPath = path.resolve('bs-config');
+var bsConfigPath = path.resolve(bsConfigName);
 var overrides = {};
 try {
   overrides = require(bsConfigPath);

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "browser-sync": "^2.11.1",
     "connect-history-api-fallback": "^1.1.0",
     "connect-logger": "0.0.1",
-    "lodash": "^4.1.0"
+    "lodash": "^4.1.0",
+    "minimist": "1.2.0"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Hey, It would be really good to have an option for custom path to configuration
especially if you hate dozen of files in your project root folder (like me)
or have to run different configuration for different needs

Thanks in advance

Regards, Dima