### PR TITLE
Added option to exclue node_modules directory by default to help alle…

### DIFF
--- a/lib/config-defaults.js
+++ b/lib/config-defaults.js
@@ -7,6 +7,9 @@ var log = require('connect-logger');
 module.exports = {
   injectChanges: false, // workaround for Angular 2 styleUrls loading
   files: ['./**/*.{html,htm,css,js}'],
+  watchOptions: {
+    ignored: "node_modules"
+  },
   server: {
     baseDir: './',
     middleware: [


### PR DESCRIPTION
#55 This pull request adds a default configuration option to exclude the node_modules directory from being watched in order to help alleviate performance issues when running lite-server for use cases like described in the [angular2 quickstart documentation](https://angular.io/docs/ts/latest/quickstart.html).