### PR TITLE
Pass browserSync instance to overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,25 @@ module.exports = {
 };
 ```
 
+The `bs-config.js` file may also export a function that receives the lite-server Browsersync instance as its only argument. While not required, the return value of this function will be used to extend the default lite-server configuration.
+```js
+module.exports = function(bs) {
+
+  return {
+    server: {
+      middleware: {
+        // overrides the second middleware default with new settings
+        1: require('connect-history-api-fallback')({
+          index: '/index.html',
+          verbose: true
+        })
+      }
+    }
+  };
+
+};
+```
+
 **NOTE:** Keep in mind that when using middleware overrides the specific middleware module must be installed in your project. For the above example, you'll need to do:
 ```bash
 $ npm install connect-history-api-fallback --save-dev

--- a/lib/lite-server.js
+++ b/lib/lite-server.js
@@ -35,6 +35,11 @@ module.exports = function start(opts, cb) {
             throw (err);
         }
     }
+
+    if (typeof overrides === 'function') {
+        overrides = overrides(browserSync);
+    }
+
     _.merge(config, overrides);
 
     // Fixes browsersync error when overriding middleware array

--- a/lib/lite-server.js
+++ b/lib/lite-server.js
@@ -6,7 +6,7 @@
  * applies custom config overrides from user's own local `bs-config.{js|json}` file,
  * and launches browser-sync.
  */
-var browserSync = require('browser-sync').create();
+var browserSync = require('browser-sync').create('lite-server');
 var path = require('path');
 var _ = require('lodash');
 var config = require('./config-defaults');


### PR DESCRIPTION
This allows for doing fun Browsersync things, like sending messages to the client in the event of an error.

```js
module.exports = function(bs) {
    'use strict';

    return {
        server: {
            middleware: {
                2: lessMiddleware
            }
        }
    };

    /**
     * Run the middleware on files that contain .less
     */
    function lessMiddleware(req, res, next) {
        if (isLessRequest(req)) {
            parseLess(req).then(function(css) {
                res.setHeader('Content-Type', 'text/css');
                res.end(css);
            }, function onError(e) {

                // Tell the client about this bad thing
                bs.notify('LESS compilation error, check yo terminal');
                
            });
        } else {
            next();
        }
    }
};
```