### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: node_js
+node_js: stable

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Lightweight *development only* node server that serves a web app, opens it in th
 
 [![Dependency Status](https://david-dm.org/johnpapa/lite-server.svg)](https://david-dm.org/johnpapa/lite-server)
 [![npm version](https://badge.fury.io/js/lite-server.svg)](http://badge.fury.io/js/lite-server)
+[![Build Status](https://travis-ci.org/johnpapa/lite-server.svg?branch=master)](https://travis-ci.org/johnpapa/lite-server)
 
 ## Why
 


### PR DESCRIPTION
Adds the `.travis.yml` for running `npm test` (which currently runs a linter, and maybe unit tests in future).

After merging, the project will need to be enabled from the owner's profile page:
<https://travis-ci.org/profile/>