### PR TITLE
Unit tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,11 @@
 module.exports = {
     "env": {
-        "node": true
+        "node": true,
+        "es6": true
     },
-    "extends": "eslint:recommended",
+    "extends": [
+        "eslint:recommended"
+    ],
     "rules": {
         "accessor-pairs": "error",
         "array-bracket-spacing": [
@@ -52,7 +55,7 @@ module.exports = {
         "id-length": "off",
         "id-match": "error",
         "indent": "error",
-        "init-declarations": "error",
+        "init-declarations": "off",
         "jsx-quotes": "error",
         "key-spacing": "error",
         "keyword-spacing": [

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .idea
+coverage/

--- a/README.md
+++ b/README.md
@@ -102,7 +102,18 @@ module.exports = {
 A list of the entire set of BrowserSync options can be found in its docs: <http://www.browsersync.io/docs/options/>
 
 ## Known Issues
+
 CSS with Angular 2 is embedded thus even though BrowserSync detects the file change to CSS, it does not inject the file via sockets. As a workaround, `injectChanges` defaults to `false`.
+
+## Contributing
+
+1. Fork and clone it
+1. Install dependencies: `npm install`
+1. Create a feature branch: `git checkout -b new-feature`
+1. Commit changes: `git commit -am 'Added a feature'`
+1. Run static code analysis and unit tests: `npm test`
+1. Push to the remote branch: `git push origin new-feature`
+1. Create a new [Pull Request](https://github.com/johnpapa/lite-server/pull/new/master)
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Lightweight development node server for serving a web app, providing a fallback for browser history API, loading in the browser, and injecting scripts on the fly.",
   "main": "index.js",
   "scripts": {
-    "test": "eslint *.js lib/*.js"
+    "test": "eslint *.js lib/*.js && istanbul cover _mocha -- -R spec"
   },
   "repository": {
     "type": "git",
@@ -28,6 +28,10 @@
     "minimist": "1.2.0"
   },
   "devDependencies": {
-    "eslint": "^2.4.0"
+    "eslint": "^2.4.0",
+    "istanbul": "^0.4.2",
+    "mocha": "^2.4.5",
+    "mockery": "^1.4.1",
+    "sinon": "^1.17.3"
   }
 }

--- a/test/config-defaults.spec.js
+++ b/test/config-defaults.spec.js
@@ -1,0 +1,50 @@
+/* global it, describe, beforeEach, afterEach */
+'use strict';
+var assert = require('assert');
+var mockery = require('mockery');
+var sinon = require('sinon');
+
+describe('config-defaults', () => {
+    var fallbackMock;
+    var loggerMock;
+
+    beforeEach(() => {
+        mockery.enable();
+
+        fallbackMock = sinon.stub();
+        mockery.registerMock('connect-history-api-fallback', fallbackMock);
+
+        loggerMock = sinon.stub();
+        mockery.registerMock('connect-logger', loggerMock);
+
+        mockery.registerAllowable('../lib/config-defaults');
+    });
+
+    afterEach(() => {
+        mockery.deregisterAll();
+        mockery.disable();
+    });
+
+    it('should provide defaults', () => {
+        fallbackMock.returns('fallback-middleware');
+        loggerMock.returns('logger-middleware');
+        var configDefaults = require('../lib/config-defaults');
+
+        assert.strictEqual(configDefaults.injectChanges, false,
+            'includes NG2 styleUrls workaround');
+        assert.ok(configDefaults.files.length,
+            'includes files array');
+        assert.strictEqual(configDefaults.watchOptions.ignored, 'node_modules',
+            'ignores node_modules from watchlist');
+        assert.ok(configDefaults.server.baseDir,
+            'includes basedir');
+        assert.deepEqual(
+            configDefaults.server.middleware,
+            ['logger-middleware', 'fallback-middleware'],
+            'includes middleware'
+        );
+        assert.ok(loggerMock.called, 'logger middleware initialized');
+        assert.ok(fallbackMock.called, 'fallback middleware initialized');
+    });
+
+});

--- a/test/lite-server.spec.js
+++ b/test/lite-server.spec.js
@@ -1,0 +1,85 @@
+/* global it, describe, beforeEach, afterEach */
+'use strict';
+var assert = require('assert');
+var mockery = require('mockery');
+var sinon = require('sinon');
+var path = require('path');
+
+describe('lite-server', () => {
+    var browserSyncMock;
+    var browserSyncMethodStubs;
+    var configDefaultsMock;
+    var consoleStubs;
+    var callbackStub;
+
+    beforeEach(() => {
+        mockery.enable();
+
+        browserSyncMethodStubs = {init: sinon.stub()};
+        browserSyncMock = sinon.stub().returns(browserSyncMethodStubs);
+        mockery.registerMock('browser-sync', {create: browserSyncMock});
+
+        consoleStubs = {
+            log: sinon.stub(),
+            info: sinon.stub()
+        };
+
+        configDefaultsMock = {
+            server: {middleware: ['m1', 'm2']}
+        };
+        mockery.registerMock('./config-defaults', configDefaultsMock);
+
+        callbackStub = sinon.stub();
+
+        mockery.registerAllowables([
+            'path', 'lodash', 'minimist', '../lib/lite-server'
+        ]);
+    });
+
+    afterEach(() => {
+        mockery.deregisterAll();
+        mockery.disable();
+    });
+
+    it('should merge configs', () => {
+        browserSyncMethodStubs.init.yields();
+        configDefaultsMock.a = 1;
+
+        var bsConfigMock = {
+            b: 2,
+            server: {
+                middleware: {
+                    0: null
+                }
+            }
+        };
+        mockery.registerMock(path.resolve('./bs-config'), bsConfigMock);
+
+        var liteServer = require('../lib/lite-server');
+        var bs = liteServer({console: consoleStubs, argv: []}, callbackStub);
+
+        assert.ok(bs.init, 'returns browsersync');
+        assert.ok(browserSyncMethodStubs.init.calledWithMatch({
+            server: {
+                middleware: ['m2']
+            },
+            a: 1,
+            b: 2
+        }), 'configs were merged');
+        assert.ok(callbackStub.called, 'callback was called');
+    });
+
+    it('should handle missing bs-config', () => {
+        mockery.registerAllowable(path.resolve('missing-config'));
+
+        var liteServer = require('../lib/lite-server');
+        var bs = liteServer({
+            console: consoleStubs,
+            argv: [null, null, '-c', 'missing-config']
+        }, callbackStub);
+
+        assert.ok(bs.init, 'returns browsersync');
+        assert.ok(consoleStubs.info.calledWithMatch('Did not detect'));
+    });
+
+});


### PR DESCRIPTION
Adds Mocha unit tests and Istanbul coverage reports.

```
$ npm test

> lite-server@2.2.0 test /Users/cmartin/Src/angular2-sandbox/lite-server
> eslint *.js lib/*.js && istanbul cover _mocha -- -R spec

  config-defaults
    ✓ should provide defaults

  lite-server
    ✓ should merge configs (65ms)
    ✓ should handle missing bs-config

  3 passing (101ms)

=============================================================================
Writing coverage object [/Users/cmartin/Src/angular2-sandbox/lite-server/coverage/coverage.json]
Writing coverage reports at [/Users/cmartin/Src/angular2-sandbox/lite-server/coverage]
=============================================================================

=============================== Coverage summary ===============================
Statements   : 96.43% ( 27/28 )
Branches     : 64.71% ( 11/17 )
Functions    : 50% ( 1/2 )
Lines        : 96.43% ( 27/28 )
================================================================================
```