### PR TITLE
Removed 'Connected to Browser Sync' messages

### DIFF
--- a/lib/config-defaults.js
+++ b/lib/config-defaults.js
@@ -8,6 +8,7 @@ var log = require('connect-logger');
 module.exports = {
     injectChanges: false, // workaround for Angular 2 styleUrls loading
     files: ['./**/*.{html,htm,css,js}'],
+    notify: false,
     watchOptions: {
         ignored: 'node_modules'
     },


### PR DESCRIPTION
Quiet "Connected to Browser-Sync" messages in the browser by adding ```notify: false``` to the default browser-sync configuration in ```lib/config.defaults.js```.