### PR TITLE
Update browser-sync reference per bug in downstream dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lite-server",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Lightweight development node server for serving a web app, providing a fallback for browser history API, loading in the browser, and injecting scripts on the fly.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/johnpapa/lite-server#readme",
   "dependencies": {
-    "browser-sync": "^2.18.5",
+    "browser-sync": "^2.24.4",
     "connect-history-api-fallback": "^1.2.0",
     "connect-logger": "0.0.1",
     "lodash": "^4.11.1",


### PR DESCRIPTION
The issue is that the latest lite-server has a dependency on browser-sync (2.18.12) > localtunnel (1.8.2) > request (2.78.0) > hawk (3.1.3) > hoek (2.16.3). Hawk has dependencies on sntp, boom, and cryptiles which all depend on hoek. Hoek < 4 has a vulnerability.

 
![image](https://user-images.githubusercontent.com/8527305/41016901-236fadec-6907-11e8-9015-d243882b813d.png)


Latest browser-sync has a dependency on localtunnel 1.9.0 where it replaces the request dependency with axios. This should fix it for us. 