### PR TITLE
Update package.json (minimist)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "connect-history-api-fallback": "^1.2.0",
     "connect-logger": "0.0.1",
     "lodash": "^4.17.15",
-    "minimist": "1.2.0"
+    "minimist": "1.2.3"
   },
   "devDependencies": {
     "eslint": "^6.0.0",


### PR DESCRIPTION
Update of package.json of minimist to minimum required version (1.2.3) which contains patches for vulnerability (Prototype Pollution) as reported in  https://npmjs.com/advisories/1179  
